### PR TITLE
Closes #27 skip cache optionally

### DIFF
--- a/src/angularStorage/services/internalStore.js
+++ b/src/angularStorage/services/internalStore.js
@@ -21,9 +21,9 @@ angular.module('angular-storage.internalStore', ['angular-storage.localStorage',
       this.storage.set(this.getNamespacedKey(name), JSON.stringify(elem));
     };
 
-    InternalStore.prototype.get = function(name) {
+    InternalStore.prototype.get = function(name, skipCache) {
       var obj = null;
-      if (name in this.inMemoryCache) {
+      if (!skipCache && name in this.inMemoryCache) {
         return this.inMemoryCache[name];
       }
       var saved = this.storage.get(this.getNamespacedKey(name));


### PR DESCRIPTION
by allowing to skip the inMemoryCache optionally, existing code will not be broken while enabling cross-tab/window sharing of (updated) JWTs
